### PR TITLE
stack_limit configuration

### DIFF
--- a/src/configuration.rs
+++ b/src/configuration.rs
@@ -29,8 +29,11 @@ pub struct SandboxConfiguration {
     /// Time limit for the execution in seconds
     pub time_limit: Option<u64>,
 
-    /// Memory limit fot the execution in bytes
+    /// Memory limit for the execution in bytes
     pub memory_limit: Option<u64>,
+
+    /// Stack limit for the execution in bytes
+    pub stack_limit: Option<u64>,
 
     /// Absolute path of the executable
     pub executable: PathBuf,
@@ -80,6 +83,7 @@ impl Default for SandboxConfiguration {
         SandboxConfiguration {
             time_limit: None,
             memory_limit: None,
+            stack_limit: None,
             executable: PathBuf::from("/bin/sh"),
             args: vec![],
             env: vec![],
@@ -113,6 +117,12 @@ impl SandboxConfiguration {
     /// Set the memory limit, in **bytes**
     pub fn memory_limit(&mut self, memory_limit: u64) -> &mut Self {
         self.memory_limit = Some(memory_limit);
+        self
+    }
+
+    /// Set the stack limit, in **bytes**
+    pub fn stack_limit(&mut self, stack_limit: u64) -> &mut Self {
+        self.stack_limit = Some(stack_limit);
         self
     }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -18,6 +18,12 @@ pub fn setup_resource_limits(config: &SandboxConfiguration) -> Result<()> {
         set_resource_limit(libc::RLIMIT_AS, memory_limit)?;
     }
 
+    if let Some(stack_limit) = config.stack_limit {
+        set_resource_limit(libc::RLIMIT_STACK, stack_limit)?;
+    } else {
+        set_resource_limit(libc::RLIMIT_STACK, libc::RLIM_INFINITY)?;
+    }
+
     if let Some(time_limit) = config.time_limit {
         set_resource_limit(libc::RLIMIT_CPU, time_limit)?;
     }


### PR DESCRIPTION
Before this patch the stack size inherited the limit from the shell, which is usually way less than the memory limit (8MB on my machine).

This patch adds an option for setting this limit:
- when specified the stack size is limited to the provided value
- when missing the stack is assumed to be unlimited (still bound by the global memory limit)