### PR TITLE
`proc` does not want options, not even "none"

### DIFF
--- a/src/linux/filesystem.rs
+++ b/src/linux/filesystem.rs
@@ -46,8 +46,9 @@ pub fn create(config: &SandboxConfiguration, sandbox_path: &Path) -> Result<()> 
     }
 
     if config.mount_proc {
-        fs::create_dir_all(sandbox_path.join("proc"))?;
-        mount(Some("proc"), &sandbox_path.join("proc"), Some("proc"), MsFlags::empty(), Some("none"))?;
+        let target = sandbox_path.join("proc");
+        fs::create_dir_all(&target)?;
+        mount(Some("proc"), &target, Some("proc"), MsFlags::empty(), None::<&str>)?;
     }
 
     // bind mount the readable directories into the sandbox


### PR DESCRIPTION
Passing Some("none") fails with EINVAL:
```
thread 'Sandbox watcher' panicked at 'Error starting sandbox watcher: Sys(EINVAL)', src/linux/mod.rs:50
```

Not sure if this is kernel-dependent, I am on `Linux 5.14.11-arch1-1 #1 SMP PREEMPT Sun, 10 Oct 2021 00:48:26 +0000 x86_64 GNU/Linux`.