### PR TITLE
Fix tests

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 name: Rust
-on: [push]
+on: [push, pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/src/tests/binary.rs
+++ b/src/tests/binary.rs
@@ -67,7 +67,7 @@ fn run_shell(command: &str) -> ExecutionResult {
 /// Test running bash
 #[test]
 fn test_echo() {
-    let output = run_shell("echo -n Hello, world!");
+    let output = run_shell("exec echo -n Hello, world!");
     assert_eq!(output.stdout, "Hello, world!");
 }
 
@@ -75,7 +75,7 @@ fn test_echo() {
 #[cfg(target_os = "linux")]
 #[test]
 fn test_ping() {
-    let output = run_shell("ping 8.8.8.8");
+    let output = run_shell("exec ping 8.8.8.8");
     assert!(!output.result.status.success());
     assert_eq!(output.result.status, ExitStatus::ExitCode(2));
 }
@@ -84,7 +84,7 @@ fn test_ping() {
 #[cfg(target_os = "linux")]
 #[test]
 fn test_curl() {
-    let output = run_shell("curl 8.8.8.8");
+    let output = run_shell("exec curl 8.8.8.8");
     assert!(!output.result.status.success());
     assert_eq!(output.result.status, ExitStatus::ExitCode(7));
 }
@@ -93,7 +93,7 @@ fn test_curl() {
 #[cfg(target_os = "linux")]
 #[test]
 fn test_chmod() {
-    let output = run_shell("touch file; chmod 777 file");
+    let output = run_shell("touch file; exec chmod 777 file");
     assert!(!output.result.status.success());
     assert_eq!(
         output.result.status.signal_name().unwrap(),


### PR DESCRIPTION
Maybe fix the tests by exec-ing inside bash.

Before, bash seems to catch the signals:

```
---- tests::binary::test_chmod stdout ----
error: test failed, to rerun pass '--lib'
stdout =
stderr = /bin/bash: line 1:     3 Bad system call         (core dumped) chmod 777 file

result = {"status":{"ExitCode":159},"resource_usage":{"memory_usage":3260416,"user_cpu_time":0.002998,"system_cpu_time":0.000627,"wall_time_usage":0.192351433}}

thread 'tests::binary::test_chmod' panicked at 'called `Option::unwrap()` on a `None` value', src/tests/binary.rs:99:44
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

Hopefully, by using exec it won't do that and simply exit inheriting the
signal.