### PR TITLE
Make sure the child process exits also on errors

### DIFF
--- a/src/linux/mod.rs
+++ b/src/linux/mod.rs
@@ -157,6 +157,9 @@ fn watcher(config: SandboxConfiguration) -> Result<SandboxExecutionResult> {
         } else {
             unreachable!("The child process must exec");
         }
+
+        // make sure the child process exits
+        std::process::exit(1);
     }
 
     // Store the PID of the child process for letting the signal handler kill the child


### PR DESCRIPTION
When the child process failes to exec() we need to make sure that the
fork exits, and does not run the parent code. This caused a quite nasty
bug during the sandbox cleanup:

- The child process sets up the various mountpoints in the user
  namespace
- There is an error and the exec() is not called
- The child does not exit() so the destructors started running *also* in
  the child process, including the one of the tmpdir of the sandbox
- The tmpdir Drop starts removing the sandbox content *including* the
  content of the bind mounts, removing also the files outside the
  sandbox

When the destructors are called by the parent process the mountpoint
contents are not removed since those were user-namespace mounts and are
not visible by the parent.

The solution is to make sure those destructors will never run, and by
using [std::process:exit()](https://doc.rust-lang.org/std/process/fn.exit.html) we make sure of that.