### PR TITLE
linux/seccomp_filter: accept pseudo syscall numbers

### DIFF
--- a/src/linux/seccomp_filter.rs
+++ b/src/linux/seccomp_filter.rs
@@ -44,8 +44,11 @@ impl SeccompFilter {
         let syscall_name = CString::new(name).unwrap();
         let syscall_num =
             unsafe { seccomp_sys::seccomp_syscall_resolve_name(syscall_name.as_ptr()) };
-        if syscall_num < 0 {
-            bail!("Error calling seccomp_syscall_resolve_name: {}", strerror());
+        if syscall_num == seccomp_sys::__NR_SCMP_ERROR {
+            bail!(
+                "Error calling seccomp_syscall_resolve_name: unknown system call: {}",
+                name
+            );
         }
         if unsafe {
             seccomp_sys::seccomp_rule_add(self.ctx, action.to_seccomp_param(), syscall_num, 0)


### PR DESCRIPTION
If the given architecture does not have the given system call, then a negative pseudo system call number is returned. This is not an error, and can be passed to other libseccomp functions.

In the case of an unknown syscall name the constant `__NR_SCMP_ERROR` is returned, so check for that.